### PR TITLE
Add JWT security and frontend login

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The database is pre-populated with 8 sample products across different categories
 - Food (Premium Coffee)
 - Clothing (Cotton T-shirt)
 
+Default admin credentials are `admin` / `password`. Authenticate via `POST /api/auth/login` to obtain a JWT.
+
 You can access the sample data through:
 - **API**: `GET http://localhost:8080/api/products`
 - **Individual product**: `GET http://localhost:8080/api/products/{id}`
@@ -51,6 +53,7 @@ The JSF frontend now includes:
 - **Styled Interface**: Clean, modern styling with alternating row colors and category badges
 - **Real-time Data**: Fetches live data from the Spring Boot backend on each page load
 - **Error Handling**: Shows appropriate messages if backend is unavailable
+- **Login Page**: Authenticate with the backend to manage products
 
 ## Development
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -37,6 +37,16 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <!-- Security dependencies -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+            <version>0.9.1</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/backend/src/main/java/com/example/backend/AuthController.java
+++ b/backend/src/main/java/com/example/backend/AuthController.java
@@ -1,0 +1,50 @@
+package com.example.backend;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtTokenUtil jwtTokenUtil;
+    private final UserService userService;
+
+    public AuthController(AuthenticationManager authenticationManager,
+                          JwtTokenUtil jwtTokenUtil,
+                          UserService userService) {
+        this.authenticationManager = authenticationManager;
+        this.jwtTokenUtil = jwtTokenUtil;
+        this.userService = userService;
+    }
+
+    @PostMapping("/login")
+    public Map<String, String> login(@RequestBody AuthRequest request) {
+        try {
+            authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getUsername(), request.getPassword())
+            );
+            UserDetails userDetails = userService.loadUserByUsername(request.getUsername());
+            String token = jwtTokenUtil.generateToken(userDetails.getUsername());
+            return Map.of("token", token);
+        } catch (AuthenticationException e) {
+            throw new RuntimeException("Invalid credentials");
+        }
+    }
+
+    public static class AuthRequest {
+        private String username;
+        private String password;
+
+        public String getUsername() { return username; }
+        public void setUsername(String username) { this.username = username; }
+        public String getPassword() { return password; }
+        public void setPassword(String password) { this.password = password; }
+    }
+}

--- a/backend/src/main/java/com/example/backend/DataLoader.java
+++ b/backend/src/main/java/com/example/backend/DataLoader.java
@@ -1,17 +1,26 @@
 package com.example.backend;
 
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.util.List;
 
+import com.example.backend.User;
+
 @Component
 public class DataLoader implements CommandLineRunner {
     private final ProductRepository repository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
-    public DataLoader(ProductRepository repository) {
+    public DataLoader(ProductRepository repository,
+                      UserRepository userRepository,
+                      PasswordEncoder passwordEncoder) {
         this.repository = repository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
@@ -23,6 +32,13 @@ public class DataLoader implements CommandLineRunner {
                 new Product(null, "Spring Boot Guide", "Book",
                         new BigDecimal("39.99"), "Books", true)
             ));
+        }
+
+        if (userRepository.count() == 0) {
+            User admin = new User("admin",
+                    passwordEncoder.encode("password"),
+                    "ADMIN");
+            userRepository.save(admin);
         }
     }
 }

--- a/backend/src/main/java/com/example/backend/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/example/backend/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.example.backend;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenUtil jwtTokenUtil;
+    private final UserService userService;
+
+    public JwtAuthenticationFilter(JwtTokenUtil jwtTokenUtil, UserService userService) {
+        this.jwtTokenUtil = jwtTokenUtil;
+        this.userService = userService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        final String header = request.getHeader("Authorization");
+        String token = null;
+        String username = null;
+
+        if (header != null && header.startsWith("Bearer ")) {
+            token = header.substring(7);
+            username = jwtTokenUtil.getUsernameFromToken(token);
+        }
+
+        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            if (jwtTokenUtil.validateToken(token)) {
+                var userDetails = userService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken auth =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/example/backend/JwtTokenUtil.java
+++ b/backend/src/main/java/com/example/backend/JwtTokenUtil.java
@@ -1,0 +1,41 @@
+package com.example.backend;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JwtTokenUtil {
+
+    private final String jwtSecret = "secret-key";
+    private final long expirationMs = 86400000; // 1 day
+
+    public String generateToken(String username) {
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
+                .signWith(SignatureAlgorithm.HS512, jwtSecret)
+                .compact();
+    }
+
+    public String getUsernameFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(jwtSecret)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(jwtSecret).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/com/example/backend/ProductController.java
+++ b/backend/src/main/java/com/example/backend/ProductController.java
@@ -2,6 +2,7 @@ package com.example.backend;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -29,21 +30,25 @@ public class ProductController {
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public Product create(@Valid @RequestBody Product p) {
         return service.create(p);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public Product update(@PathVariable Long id, @Valid @RequestBody Product p) {
         return service.update(id, p);
     }
 
     @PatchMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public Product partial(@PathVariable Long id, @RequestBody Map<String, Object> updates) {
         return service.partialUpdate(id, updates);
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public void delete(@PathVariable Long id) {
         service.delete(id);
     }

--- a/backend/src/main/java/com/example/backend/SecurityConfig.java
+++ b/backend/src/main/java/com/example/backend/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.example.backend;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true)
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
+        this.jwtFilter = jwtFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .authorizeRequests()
+                .antMatchers("/api/auth/login").permitAll()
+                .anyRequest().authenticated();
+
+        http.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/com/example/backend/User.java
+++ b/backend/src/main/java/com/example/backend/User.java
@@ -1,0 +1,58 @@
+package com.example.backend;
+
+import javax.persistence.*;
+
+@Entity
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String username;
+
+    private String password;
+
+    private String role;
+
+    public User() {
+    }
+
+    public User(String username, String password, String role) {
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public void setRole(String role) {
+        this.role = role;
+    }
+}

--- a/backend/src/main/java/com/example/backend/UserRepository.java
+++ b/backend/src/main/java/com/example/backend/UserRepository.java
@@ -1,0 +1,9 @@
+package com.example.backend;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/backend/src/main/java/com/example/backend/UserService.java
+++ b/backend/src/main/java/com/example/backend/UserService.java
@@ -1,0 +1,27 @@
+package com.example.backend;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService implements UserDetailsService {
+
+    private final UserRepository repository;
+
+    public UserService(UserRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return repository.findByUsername(username)
+                .map(u -> User.withUsername(u.getUsername())
+                        .password(u.getPassword())
+                        .roles(u.getRole())
+                        .build())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+}

--- a/frontend/src/main/java/com/example/frontend/LoginBean.java
+++ b/frontend/src/main/java/com/example/frontend/LoginBean.java
@@ -1,0 +1,46 @@
+package com.example.frontend;
+
+import javax.enterprise.context.SessionScoped;
+import javax.inject.Named;
+import java.io.Serializable;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Named("loginBean")
+@SessionScoped
+public class LoginBean implements Serializable {
+
+    private String username;
+    private String password;
+    private String token;
+
+    public String login() {
+        try {
+            URL url = new URL("http://backend:8080/api/auth/login");
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("POST");
+            conn.setRequestProperty("Content-Type", "application/json");
+            conn.setDoOutput(true);
+            String body = String.format("{\"username\":\"%s\",\"password\":\"%s\"}", username, password);
+            conn.getOutputStream().write(body.getBytes());
+
+            if (conn.getResponseCode() == 200) {
+                ObjectMapper mapper = new ObjectMapper();
+                var node = mapper.readTree(new InputStreamReader(conn.getInputStream()));
+                token = node.get("token").asText();
+                return "/index.xhtml?faces-redirect=true";
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+    public String getToken() { return token; }
+}

--- a/frontend/src/main/java/com/example/frontend/ProductBean.java
+++ b/frontend/src/main/java/com/example/frontend/ProductBean.java
@@ -2,6 +2,7 @@ package com.example.frontend;
 
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
 import javax.inject.Named;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,6 +17,9 @@ import java.util.List;
 @RequestScoped
 public class ProductBean {
     private List<Product> products;
+
+    @Inject
+    private LoginBean loginBean;
 
     @PostConstruct
     public void init() {
@@ -33,6 +37,9 @@ public class ProductBean {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Accept", "application/json");
+            if (loginBean != null && loginBean.getToken() != null) {
+                conn.setRequestProperty("Authorization", "Bearer " + loginBean.getToken());
+            }
 
             if (conn.getResponseCode() == 200) {
                 ObjectMapper mapper = new ObjectMapper();

--- a/frontend/src/main/webapp/index.xhtml
+++ b/frontend/src/main/webapp/index.xhtml
@@ -21,6 +21,7 @@
     <div class="header-info">
         <p>JSF Frontend displaying products from Spring Boot backend API</p>
         <p>Total products: #{productBean.products.size()}</p>
+        <p><a href="login.xhtml">Login</a></p>
     </div>
     
     <h:dataTable value="#{productBean.products}" var="product" 

--- a/frontend/src/main/webapp/login.xhtml
+++ b/frontend/src/main/webapp/login.xhtml
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:h="http://xmlns.jcp.org/jsf/html">
+<h:head>
+    <title>Login</title>
+</h:head>
+<h:body>
+    <h:form id="loginForm">
+        <h:panelGrid columns="2">
+            <h:outputLabel value="Username" for="username"/>
+            <h:inputText id="username" value="#{loginBean.username}"/>
+            <h:outputLabel value="Password" for="password"/>
+            <h:inputSecret id="password" value="#{loginBean.password}"/>
+            <h:commandButton value="Login" action="#{loginBean.login}"/>
+        </h:panelGrid>
+        <h:messages/>
+    </h:form>
+</h:body>
+</html>


### PR DESCRIPTION
## Summary
- introduce Spring Security with JWT for backend
- restrict product modification endpoints to ADMIN role
- add default admin user via DataLoader
- implement login page and JSF beans to store JWT
- document authentication info in README

## Testing
- `mvn -f backend/pom.xml test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750381f0448330b9ace6fa93b0152a